### PR TITLE
Add curl option support in Image class

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -12,6 +12,7 @@ namespace DantSu\PHPImageEditor;
  */
 class Image
 {
+
     const ALIGN_LEFT = 'left';
     const ALIGN_CENTER = 'center';
     const ALIGN_RIGHT = 'right';
@@ -35,6 +36,16 @@ class Image
      * @var $height int
      */
     private $height;
+
+    /**
+     * @array $curlOptions array
+     * Default curl options for the Image library
+     */
+    private $curlOptions = [
+        CURLOPT_USERAGENT => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0',
+        CURLOPT_RETURNTRANSFER => 1,
+        CURLOPT_TIMEOUT => 5,
+    ];
 
     public function __clone()
     {
@@ -284,27 +295,35 @@ class Image
      * (Static method) Open image from URL with cURL.
      *
      * @param string $url Url of the image file
+     * @param array $curlOptions cURL options
+     * @param bool $failOnError If true, throw an exception if the url cannot be loaded
      * @return Image Return Image instance
      */
-    public static function fromCurl(string $url): Image
+    public static function fromCurl(string $url, array $curlOptions = [], bool $failOnError = false): Image
     {
-        return (new Image)->curl($url);
+        return (new Image)->curl($url, $curlOptions, $failOnError);
     }
 
     /**
      * Open image from URL with cURL.
      *
      * @param string $url Url of the image file
+     * @param array $curlOptions cURL options
+     * @param bool $failOnError If true, throw an exception if the url cannot be loaded
      * @return $this Fluent interface
      */
-    public function curl(string $url): Image
+    public function curl(string $url, array $curlOptions = [], bool $failOnError = false): Image
     {
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt($curl, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0');
-        curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($curl, CURLOPT_TIMEOUT, 5);
+        curl_setopt_array($curl, $this->curlOptions + $curlOptions);
+
         $image = curl_exec($curl);
+
+        if($failOnError && curl_errno($curl)){
+            throw new \Exception(curl_error($curl));
+        }
+
         curl_close($curl);
 
         if ($image === false) {

--- a/src/Image.php
+++ b/src/Image.php
@@ -37,16 +37,6 @@ class Image
      */
     private $height;
 
-    /**
-     * @array $curlOptions array
-     * Default curl options for the Image library
-     */
-    private $curlOptions = [
-        CURLOPT_USERAGENT => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0',
-        CURLOPT_RETURNTRANSFER => 1,
-        CURLOPT_TIMEOUT => 5,
-    ];
-
     public function __clone()
     {
         $srcInstance = $this->image;
@@ -314,9 +304,15 @@ class Image
      */
     public function curl(string $url, array $curlOptions = [], bool $failOnError = false): Image
     {
+        $defaultCurlOptions = [
+            CURLOPT_USERAGENT => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:106.0) Gecko/20100101 Firefox/106.0',
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_TIMEOUT => 5,
+        ];
+    
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_URL, $url);
-        curl_setopt_array($curl, $this->curlOptions + $curlOptions);
+        curl_setopt_array($curl, $defaultCurlOptions + $curlOptions);
 
         $image = curl_exec($curl);
 


### PR DESCRIPTION
I'm primarily using php-image-editor because I've been testing out php-osm-static-api.  I noticed a couple of things that could help with crafting curl requests, and handling failures.  A great example where allowing failOnError is when you want to catch a URL that either isn't resolving, or returning a status that isn't 200.

My use case would be, if one image processing instance is down, allow fail over to another by using a try catch in my code.

This pull request contains the following for the reasons stated above.

- Make it so the curl features of the library support a curl options array for things like timeouts, useragents, SSL Key checks etc.

- Support fail on error for curl requests as well.  The library didn't appear to have any way to bubble up a problem when the curl didn't succeed. $failOnError=true will throw an exception when there is an error.