### PR TITLE
Fixed spacing for utf-8 strings

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -974,8 +974,9 @@ class Image
             $bottom = 0;
 
             for ($i = 0; $i < $length; ++$i) {
-                \imagettftext($image, $size, $angle, $letterPos['x'], $letterPos['y'], $color, $font, $text[$i]);
-                $bbox = \imagettfbbox($size, 0, $font, $text[$i]);
+                $char = \mb_substr($text, $i, 1);
+                \imagettftext($image, $size, $angle, $letterPos['x'], $letterPos['y'], $color, $font, $char);
+                $bbox = \imagettfbbox($size, 0, $font, $char);
                 $letterPos = Geometry2D::getDstXY($letterPos['x'], $letterPos['y'], $angle, $spacing + $bbox[2]);
 
                 $textWidth += $bbox[2];


### PR DESCRIPTION
With the current spacing, the library split a string by each letter to place a bounding box after each letter. This works well for all characters, except for special characters. Using mb_substr fixes this issue.

Before:
![Screenshot from 2023-05-04 17-49-27](https://user-images.githubusercontent.com/9220754/236261050-96959db2-f127-47bf-a285-5b56df053249.png)

After:

![Screenshot from 2023-05-04 17-49-54](https://user-images.githubusercontent.com/9220754/236261224-2db4fb15-ab87-4216-8493-9b07bd2e40e2.png)
