### PR TITLE
Do not fail on undefined request scheme

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -308,7 +308,7 @@ class Image
     {
         $defaultCurlOptions = [
             CURLOPT_USERAGENT => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/116.0',
-            CURLOPT_REFERER => \strtolower($_SERVER["REQUEST_SCHEME"] . '://' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"]),
+            CURLOPT_REFERER => \strtolower(($_SERVER["REQUEST_SCHEME"] ?? 'http') . '://' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"]),
             CURLOPT_RETURNTRANSFER => 1,
             CURLOPT_TIMEOUT => 5,
         ];


### PR DESCRIPTION
When using local PHP server, the 'REQUEST_SCHEME' is empty for me, causing the script to fail:

`Warning: Undefined array key "REQUEST_SCHEME"`

This will fallback to 'http' when REQUEST_SCHEME is set.