### PR TITLE
Adding mbstring as a requirement for this package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
   ],
   "require": {
     "php": ">=7.0",
-    "ext-gd": "*"
+    "ext-gd": "*",
+    "ext-mbstring": "*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Without `mbstring` this line throws a fatal error:

https://github.com/DantSu/php-image-editor/blob/59a3e922000767051d380a2c530c61344f1e79ec/src/Image.php#L620

```
Fatal error: Uncaught Error: Call to undefined function mb_strlen() in /srv/.../www/vendor/dantsu/php-image-editor/src/Image.php:620 
```